### PR TITLE
fix: passing node-glob options in async

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function (patterns, opts, cb) {
 	var force = opts.force;
 	delete opts.force;
 
-	globby(patterns, function (err, files) {
+	globby(patterns, opts, function (err, files) {
 		if (err) {
 			cb(err);
 			return;

--- a/test.js
+++ b/test.js
@@ -1,22 +1,33 @@
+/*global it, beforeEach, afterEach */
 'use strict';
 var assert = require('assert');
 var fs = require('fs-extra');
 var del = require('./');
 
 beforeEach(function () {
-	fs.writeFileSync('1.tmp', '');
-	fs.writeFileSync('2.tmp', '');
-	fs.writeFileSync('3.tmp', '');
-	fs.writeFileSync('4.tmp', '');
+	[
+		'1.tmp',
+		'2.tmp',
+		'3.tmp',
+		'4.tmp',
+		'.dot.tmp'
+	].forEach(function(path) {
+		fs.writeFileSync(path, '');
+	});
 });
 
 afterEach(function () {
-	try {
-		fs.unlinkSync('1.tmp');
-		fs.unlinkSync('2.tmp');
-		fs.unlinkSync('3.tmp');
-		fs.unlinkSync('4.tmp');
-	} catch (err) {}
+	[
+		'1.tmp',
+		'2.tmp',
+		'3.tmp',
+		'4.tmp',
+		'.dot.tmp'
+	].forEach(function(path) {
+		try {
+			fs.unlinkSync(path);
+		} catch (err) {}
+	});
 });
 
 it('should delete files async', function (cb) {
@@ -26,6 +37,7 @@ it('should delete files async', function (cb) {
 		assert(!fs.existsSync('2.tmp'));
 		assert(!fs.existsSync('3.tmp'));
 		assert(!fs.existsSync('4.tmp'));
+		assert(fs.existsSync('.dot.tmp'));
 		cb();
 	});
 });
@@ -36,4 +48,26 @@ it('should delete files sync', function () {
 	assert(!fs.existsSync('2.tmp'));
 	assert(!fs.existsSync('3.tmp'));
 	assert(!fs.existsSync('4.tmp'));
+	assert(fs.existsSync('.dot.tmp'));
+});
+
+it('should take account of options (async)', function(cb) {
+	del(['*.tmp', '!1*'], {dot: true}, function (err) {
+		assert(!err, err);
+		assert(fs.existsSync('1.tmp'));
+		assert(!fs.existsSync('2.tmp'));
+		assert(!fs.existsSync('3.tmp'));
+		assert(!fs.existsSync('4.tmp'));
+		assert(!fs.existsSync('.dot.tmp'));
+		cb();
+	});
+});
+
+it('should take account of options (sync)', function () {
+	del.sync(['*.tmp', '!1*'], {dot: true});
+	assert(fs.existsSync('1.tmp'));
+	assert(!fs.existsSync('2.tmp'));
+	assert(!fs.existsSync('3.tmp'));
+	assert(!fs.existsSync('4.tmp'));
+	assert(!fs.existsSync('.dot.tmp'));
 });


### PR DESCRIPTION
I've missed node-glob `options` for: 

``` javascript
var del = require('del'),
    options = {dot: true};
del(['build/**/*', '!build/.git/**'], options, cb);
```
