### PR TITLE
Remove `err` callback from usage example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ $ npm install --save del
 ```js
 var del = require('del');
 
-del(['tmp/*.js', '!tmp/unicorn.js'], function (err) {
+del(['tmp/*.js', '!tmp/unicorn.js'], function () {
 	console.log('Files deleted');
 });
 ```


### PR DESCRIPTION
Removed it since it's not being used —but maybe you like it that way. Silly PR anyway. :)
