### PR TITLE
Make CLI support clearer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Allow deleting the current working directory and files/folders outside it.
 
 ## CLI
 
-See [trash](https://github.com/sindresorhus/trash).
+del doesn't offer usage via the CLI.  Instead, see [trash](https://github.com/sindresorhus/trash).
 
 
 ## License


### PR DESCRIPTION
When I originally read the CLI verbiage in usage section on the README, I took it as "use the trash CLI syntax/etc for del CLI usage".  This change makes it a bit more explicit.