### PR TITLE
Async: expose a Promise API rather than accepting a callback.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,12 @@
   ],
   "dependencies": {
     "each-async": "^1.0.0",
-    "globby": "^2.0.0",
+    "globby": "^3.0.0",
     "is-path-cwd": "^1.0.0",
     "is-path-in-cwd": "^1.0.0",
     "object-assign": "^3.0.0",
+    "pify": "^1.0.0",
+    "pinkie-promise": "^1.0.0",
     "rimraf": "^2.2.8"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Delete files/folders using [globs](https://github.com/isaacs/minimatch#usage)
 
-Pretty much [rimraf](https://github.com/isaacs/rimraf) with support for multiple files and globbing.  
+Pretty much [rimraf](https://github.com/isaacs/rimraf) with a Promise API and support for multiple files and globbing.  
 It also protects you against deleting the current working directory and above.
 
 
@@ -18,7 +18,7 @@ $ npm install --save del
 ```js
 var del = require('del');
 
-del(['tmp/*.js', '!tmp/unicorn.js'], function (err, paths) {
+del(['tmp/*.js', '!tmp/unicorn.js']).then(function (paths) {
 	console.log('Deleted files/folders:\n', paths.join('\n'));
 });
 ```
@@ -43,10 +43,13 @@ del.sync(['public/assets/**', '!public/assets', '!public/assets/goat.png']);
 
 ## API
 
-### del(patterns, [options], callback)
+### del(patterns, [options])
+
+Returns a promise that resolves to an array of the deleted paths.
+
 ### del.sync(patterns, [options])
 
-The async method gets an array of deleted paths as the second argument in the callback, while the sync method returns the array.
+Returns an array of deleted paths.
 
 #### patterns
 

--- a/test.js
+++ b/test.js
@@ -24,15 +24,13 @@ afterEach(function () {
 	].forEach(fs.removeSync);
 });
 
-it('should delete files - async', function (cb) {
-	del(['*.tmp', '!1*'], function (err) {
-		assert(!err, err);
+it('should delete files - async', function () {
+	return del(['*.tmp', '!1*']).then(function () {
 		assert(pathExists.sync('1.tmp'));
 		assert(!pathExists.sync('2.tmp'));
 		assert(!pathExists.sync('3.tmp'));
 		assert(!pathExists.sync('4.tmp'));
 		assert(pathExists.sync('.dot.tmp'));
-		cb();
 	});
 });
 
@@ -45,15 +43,13 @@ it('should delete files - sync', function () {
 	assert(pathExists.sync('.dot.tmp'));
 });
 
-it('should take account of options - async', function (cb) {
-	del(['*.tmp', '!1*'], {dot: true}, function (err) {
-		assert(!err, err);
+it('should take account of options - async', function () {
+	return del(['*.tmp', '!1*'], {dot: true}).then(function () {
 		assert(pathExists.sync('1.tmp'));
 		assert(!pathExists.sync('2.tmp'));
 		assert(!pathExists.sync('3.tmp'));
 		assert(!pathExists.sync('4.tmp'));
 		assert(!pathExists.sync('.dot.tmp'));
-		cb();
 	});
 });
 
@@ -74,15 +70,13 @@ it('cwd option - sync', function () {
 	fs.remove(f);
 });
 
-it('cwd option - async', function (cb) {
+it('cwd option - async', function () {
 	var f = 'tmp/tmp.txt';
 	fs.ensureFileSync(f);
 
-	del('tmp.txt', {cwd: 'tmp'}, function (err) {
-		assert(!err, err);
+	return del('tmp.txt', {cwd: 'tmp'}).then(function () {
 		assert(!pathExists.sync(f));
 		fs.remove(f);
-		cb();
 	});
 });
 
@@ -96,15 +90,13 @@ it('return deleted files - sync', function () {
 	assert(/1\.tmp$/.test(del.sync('1.tmp')[0]));
 });
 
-it('return deleted files - async', function (cb) {
-	del('1.tmp', function (err, deletedFiles) {
-		assert(!err, err);
+it('return deleted files - async', function () {
+	return del('1.tmp', function (deletedFiles) {
 		assert(/1\.tmp$/.test(deletedFiles[0]));
-		cb();
 	});
 });
 
-it('options are optional', function (cb) {
+it('options are optional', function () {
 	del.sync('1.tmp');
-	del('1.tmp', cb);
+	return del('1.tmp');
 });


### PR DESCRIPTION
Resolves #28 

Let me know if this is in line with what you're expecting :smile: 

We could even push the Promise constructor down to globby, but that would require a breaking API change there too. And I doubt `rimraf` will adopt them, but that's fine.

I've left the version alone and up to you since this is a pretty breaking change with the removal of the callback interface :stuck_out_tongue: 