### PR TITLE
fix/unify return values of sync and async

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,14 +26,14 @@ module.exports = function (patterns, opts) {
 	delete opts.force;
 
 	return globby(patterns, opts).then(function (files) {
-		return Promise.all(files.map(function (x) {
+		return Promise.all(files.map(function (file) {
 			if (!force) {
-				safeCheck(x);
+				safeCheck(file);
 			}
 
-			x = path.resolve(opts.cwd || '', x);
+			file = path.resolve(opts.cwd || '', file);
 
-			return rimrafP(x).then(function () {
+			return rimrafP(file).then(function () {
 				return files;
 			});
 		})).then(function (args) {
@@ -48,14 +48,14 @@ module.exports.sync = function (patterns, opts) {
 	var force = opts.force;
 	delete opts.force;
 
-	return globby.sync(patterns, opts).map(function (x) {
+	return globby.sync(patterns, opts).map(function (file) {
 		if (!force) {
-			safeCheck(x);
+			safeCheck(file);
 		}
 
-		x = path.resolve(opts.cwd || '', x);
-		rimraf.sync(x);
+		file = path.resolve(opts.cwd || '', file);
+		rimraf.sync(file);
 
-		return x;
+		return file;
 	});
 };

--- a/index.js
+++ b/index.js
@@ -34,11 +34,9 @@ module.exports = function (patterns, opts) {
 			file = path.resolve(opts.cwd || '', file);
 
 			return rimrafP(file).then(function () {
-				return files;
+				return file;
 			});
-		})).then(function (args) {
-			return args[0];
-		});
+		}));
 	});
 };
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 'use strict';
 var assert = require('assert');
 var fs = require('fs-extra');
+var path = require('path');
 var pathExists = require('path-exists');
 var del = require('./');
 
@@ -77,12 +78,14 @@ it('cwd option - async', function () {
 });
 
 it('return deleted files - sync', function () {
-	assert(/1\.tmp$/.test(del.sync('1.tmp')[0]));
+	fs.ensureFileSync('tmp/tmp.txt');
+	assert.deepEqual(del.sync('tmp.txt', {cwd: 'tmp'}), [path.resolve('tmp/tmp.txt')]);
 });
 
 it('return deleted files - async', function () {
-	return del('1.tmp').then(function (deletedFiles) {
-		assert(/1\.tmp$/.test(deletedFiles[0]));
+	fs.ensureFileSync('tmp/tmp.txt');
+	return del('tmp.txt', {cwd: 'tmp'}).then(function (deletedFiles) {
+		assert.deepEqual(deletedFiles, [path.resolve('tmp/tmp.txt')]);
 	});
 });
 


### PR DESCRIPTION
`async` returns unresolved paths  for quite some time (in contrast to `sync`).

This PR reverts to the old behavior.