### PR TITLE
Use `ava` instead of `mocha` and ES2015ify tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && mocha"
+    "test": "xo && ava"
   },
   "files": [
     "index.js"
@@ -52,15 +52,9 @@
     "rimraf": "^2.2.8"
   },
   "devDependencies": {
+    "ava": "*",
     "fs-extra": "^0.26.2",
-    "mocha": "*",
     "path-exists": "^2.0.0",
     "xo": "*"
-  },
-  "xo": {
-    "envs": [
-      "node",
-      "mocha"
-    ]
   }
 }


### PR DESCRIPTION
Didn't care about the wording in the titles, but I guess you want to remove `should`. Also, had to run them in serial because of the fixture creation and deletion before and after every test.