### PR TITLE
Allow use from scripts hash and command line

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+'use strict';
+var meow = require('meow');
+var del = require('.');
+
+var cli = meow(`
+		Usage
+			$ del /oh/my/glob/*.js
+
+		Options
+			-f, --force  Force deletion
+			-d, --dryRun Print what would have been deleted
+
+		Examples
+		$ del /oh/my/glob/*.js --force --dryRun
+`, {
+	alias: {
+		f: 'force',
+		d: 'dryRun'
+	}
+});
+
+del.sync(cli.input, cli.flags);

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
     "test": "xo && ava"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "bin.js"
   ],
+  "bin": "./bin.js",
   "keywords": [
     "delete",
     "del",
@@ -46,6 +48,7 @@
     "globby": "^4.0.0",
     "is-path-cwd": "^1.0.0",
     "is-path-in-cwd": "^1.0.0",
+    "meow": "^3.7.0",
     "object-assign": "^4.0.1",
     "pify": "^2.0.0",
     "pinkie-promise": "^2.0.0",


### PR DESCRIPTION
Allows for the use of `del` in the scripts tag of package.json.  For example

```javascript
{
  "name": "my-package",
  "scripts": {
    "clean": "del npm-debug.log*"
  }
}
```

Also allows use from command line

```shell
npm i -g del
del npm-debug.log*
```