### PR TITLE
Update link to patterns examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Type: `string` `Array`
 
 See supported minimatch [patterns](https://github.com/isaacs/minimatch#usage).
 
-- [Pattern examples with expected matches](https://github.com/sindresorhus/multimatch/blob/master/test.js)
+- [Pattern examples with expected matches](https://github.com/sindresorhus/multimatch/blob/master/test/test.js)
 - [Quick globbing pattern overview](https://github.com/sindresorhus/multimatch#globbing-patterns)
 
 #### options


### PR DESCRIPTION
It's no longer pointing to the right file