### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - 'node'
+  - '10'
   - '8'
   - '6'
-  - '4'


### PR DESCRIPTION
Node.js 4 has reached its EOL. We should test current LTS (6, 8 and 10) and stable (node).