### PR TITLE
CHANGED: do not throw on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function safeCheck(file) {
 const del = (patterns, options) => {
 	options = Object.assign({}, options);
 
-	const {force, dryRun} = options;
+	const { force, dryRun } = options;
 	delete options.force;
 	delete options.dryRun;
 
@@ -37,10 +37,14 @@ const del = (patterns, options) => {
 			return file;
 		}
 
-		return rimrafP(file, {glob: false}).then(() => file);
+		// do not throw on error, silentely catch it: errors will be filtered below
+		return rimrafP(file, { glob: false }).then(() => file).catch(() => null);
 	};
 
-	return globby(patterns, options).then(files => pMap(files, mapper, options));
+	return globby(patterns, options).then(files => {
+		return pMap(files, mapper, options)
+			.filter((file) => file !== null);
+	});
 };
 
 module.exports = del;
@@ -50,7 +54,7 @@ module.exports.default = del;
 module.exports.sync = (patterns, options) => {
 	options = Object.assign({}, options);
 
-	const {force, dryRun} = options;
+	const { force, dryRun } = options;
 	delete options.force;
 	delete options.dryRun;
 
@@ -62,7 +66,7 @@ module.exports.sync = (patterns, options) => {
 		file = path.resolve(options.cwd || '', file);
 
 		if (!dryRun) {
-			rimraf.sync(file, {glob: false});
+			rimraf.sync(file, { glob: false });
 		}
 
 		return file;


### PR DESCRIPTION
del makes use of the `globby` package which takes a list of globs as parameter and returns a promise with the list of valid patterns.

So, with this directory tree:

```
/foo
/foo/bar
/access_denied
```

The code `globby(['/bar', '/foo']) would return `['/foo']`.

So calling del(['/bar', '/foo']) would simply delete `/foo` and return `['/foo'] without any error.

While calling `del(['access_denied', '/foo'])` would reject the promise with a permission error, but `/foo` would have been deleted and there's no way to know it.

This pull_request attempts to make error handling more consistent, so both previous calls would return `['/foo']` so the developer can find if there was an error by comparing the original array and the returned array's length.