### PR TITLE
Prevent race condition on macOS when deleting files 

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ module.exports = async (patterns, {force, dryRun, ...options} = {}) => {
 		...options
 	};
 
-	const files = await globby(patterns, options);
+	const files = (await globby(patterns, options))
+		.sort((a, b) => b.localeCompare(a));
 
 	const mapper = async file => {
 		if (!force) {
@@ -54,7 +55,10 @@ module.exports.sync = (patterns, {force, dryRun, ...options} = {}) => {
 		...options
 	};
 
-	return globby.sync(patterns, options).map(file => {
+	const files = globby.sync(patterns, options)
+		.sort((a, b) => b.localeCompare(a));
+
+	return files.map(file => {
 		if (!force) {
 			safeCheck(file);
 		}


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/del/issues/68.

I first solved it with the following code:
```js
if (!dryRun) {
    try {
        await rimrafP(file, {glob: false});
    } catch (error) {
        if (error.code === 'EINVAL') {
            await rimrafP(file, {glob: false});
        } else {
            throw error;
        }
    }
}
```

If I should add this back as an additional fail-safe let me know.