### PR TITLE
Pass options to rimraf

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,37 @@
+import * as fs from 'fs';
 import {GlobbyOptions} from 'globby';
 
+interface ExternalOptions extends GlobbyOptions {
+	/**
+	 Windows: EBUSY and ENOTEMPTY - rimraf will back off a maximum of opts.maxBusyTries times before giving up, adding 100ms of wait between each attempt.
+
+	 @default 3
+	 */
+	readonly maxBusyTries?: number;
+
+	/**
+	 Since readdir requires opening a file descriptor, it's possible to hit EMFILE if too many file descriptors are in use. In the sync case, there's nothing to be done for this. But in the async case, rimraf will gradually back off with timeouts up to opts.emfileWait ms, which defaults to 1000.
+
+	 @default 1000
+	 */
+	readonly emfileWait?: number;
+
+	readonly unlink?: typeof fs.unlink;
+	readonly unlinkSync?: typeof fs.unlinkSync;
+	readonly chmod?: typeof fs.chmod;
+	readonly chmodSync?: typeof fs.chmodSync;
+	readonly stat?: typeof fs.stat;
+	readonly statSync?: typeof fs.statSync;
+	readonly lstat?: typeof fs.lstat;
+	readonly lstatSync?: typeof fs.lstatSync;
+	readonly rmdir?: typeof fs.rmdir;
+	readonly rmdirSync?: typeof fs.rmdirSync;
+	readonly readdir?: typeof fs.readdir;
+	readonly readdirSync?: typeof fs.readdirSync;
+}
+
 declare namespace del {
-	interface Options extends GlobbyOptions {
+	interface Options extends ExternalOptions {
 		/**
 		Allow deleting the current working directory and outside.
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const {promisify} = require('util');
 const path = require('path');
 const globby = require('globby');
+const gracefulFs = require('graceful-fs');
 const isPathCwd = require('is-path-cwd');
 const isPathInside = require('is-path-inside');
 const rimraf = require('rimraf');
@@ -27,18 +28,18 @@ function sortOptions(options) {
 
 		maxBusyTries,
 		emfileWait,
-		unlink,
-		unlinkSync,
-		chmod,
-		chmodSync,
-		stat,
-		statSync,
-		lstat,
-		lstatSync,
-		rmdir,
-		rmdirSync,
-		readdir,
-		readdirSync,
+		unlink = gracefulFs.unlink,
+		unlinkSync = gracefulFs.unlinkSync,
+		chmod = gracefulFs.chmod,
+		chmodSync = gracefulFs.chmodSync,
+		stat = gracefulFs.stat,
+		statSync = gracefulFs.statSync,
+		lstat = gracefulFs.lstat,
+		lstatSync = gracefulFs.lstatSync,
+		rmdir = gracefulFs.rmdir,
+		rmdirSync = gracefulFs.rmdirSync,
+		readdir = gracefulFs.readdir,
+		readdirSync = gracefulFs.readdirSync,
 
 		...globbyOptions
 	} = options;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,10 +1,28 @@
-import {expectType} from 'tsd';
+import * as fs from 'fs';
+import { expectType } from 'tsd';
 import del = require('.');
 
 const paths = [
 	'temp/*.js',
 	'!temp/unicorn.js'
 ];
+
+const rimrafOptions: del.Options = {
+	maxBusyTries: 1000,
+	emfileWait: 3,
+	unlink: fs.unlink,
+	unlinkSync: fs.unlinkSync,
+	chmod: fs.chmod,
+	chmodSync: fs.chmodSync,
+	stat: fs.stat,
+	statSync: fs.statSync,
+	lstat: fs.lstat,
+	lstatSync: fs.lstatSync,
+	rmdir: fs.rmdir,
+	rmdirSync: fs.rmdirSync,
+	readdir: fs.readdir,
+	readdirSync: fs.readdirSync,
+};
 
 // Del
 expectType<Promise<string[]>>(del('temp/*.js'));
@@ -14,6 +32,7 @@ expectType<Promise<string[]>>(del(paths, {force: true}));
 expectType<Promise<string[]>>(del(paths, {dryRun: true}));
 expectType<Promise<string[]>>(del(paths, {concurrency: 20}));
 expectType<Promise<string[]>>(del(paths, {cwd: ''}));
+expectType<Promise<string[]>>(del(paths, rimrafOptions));
 
 // Del (sync)
 expectType<string[]>(del.sync('tmp/*.js'));
@@ -23,3 +42,4 @@ expectType<string[]>(del.sync(paths, {force: true}));
 expectType<string[]>(del.sync(paths, {dryRun: true}));
 expectType<string[]>(del.sync(paths, {concurrency: 20}));
 expectType<string[]>(del.sync(paths, {cwd: ''}));
+expectType<string[]>(del.sync(paths, rimrafOptions));

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 	],
 	"dependencies": {
 		"globby": "^10.0.0",
+		"graceful-fs": "^4.2.0",
 		"is-path-cwd": "^2.0.0",
 		"is-path-inside": "^3.0.1",
 		"p-map": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,9 @@ See the supported [glob patterns](https://github.com/sindresorhus/globby#globbin
 
 Type: `object`
 
-You can specify any of the [`globby` options](https://github.com/sindresorhus/globby#options) in addition to the below options. In constrast to the `globby` defaults, `expandDirectories`, `onlyFiles`, and `followSymbolicLinks` are `false` by default.
+You can specify any of the [`globby` options](https://github.com/sindresorhus/globby#options) or [`rimraf` options](https://github.com/isaacs/rimraf#options) in addition to the below options.
+
+In contrast to the `globby` defaults, `expandDirectories`, `onlyFiles`, and `followSymbolicLinks` are `false` by default.
 
 ##### force
 


### PR DESCRIPTION
I've wanted to add options to rimraf but haven't been able to.

This also defaults to use [`graceful-fs`](https://github.com/isaacs/node-graceful-fs#) to help prevent various fs errors. If this isn't wanted I can remove it.