### PR TITLE
Reverse order back for the returned paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,11 @@ module.exports = async (patterns, {force, dryRun, cwd = process.cwd(), ...option
 		return file;
 	};
 
-	return pMap(files, mapper, options);
+	const removedFiles = await pMap(files, mapper, options);
+
+	removedFiles.reverse();
+
+	return removedFiles;
 };
 
 module.exports.sync = (patterns, {force, dryRun, cwd = process.cwd(), ...options} = {}) => {
@@ -60,7 +64,7 @@ module.exports.sync = (patterns, {force, dryRun, cwd = process.cwd(), ...options
 	const files = globby.sync(patterns, options)
 		.sort((a, b) => b.localeCompare(a));
 
-	return files.map(file => {
+	const removedFiles = files.map(file => {
 		file = path.resolve(cwd, file);
 
 		if (!force) {
@@ -73,4 +77,8 @@ module.exports.sync = (patterns, {force, dryRun, cwd = process.cwd(), ...options
 
 		return file;
 	});
+
+	removedFiles.reverse();
+
+	return removedFiles;
 };

--- a/test.js
+++ b/test.js
@@ -90,9 +90,9 @@ test('don\'t delete files, but return them - async', async t => {
 	});
 	exists(t, ['1.tmp', '2.tmp', '3.tmp', '4.tmp', '.dot.tmp']);
 	t.deepEqual(deletedFiles, [
-		path.join(t.context.tmp, '4.tmp'),
+		path.join(t.context.tmp, '2.tmp'),
 		path.join(t.context.tmp, '3.tmp'),
-		path.join(t.context.tmp, '2.tmp')
+		path.join(t.context.tmp, '4.tmp')
 	]);
 });
 
@@ -103,9 +103,9 @@ test('don\'t delete files, but return them - sync', t => {
 	});
 	exists(t, ['1.tmp', '2.tmp', '3.tmp', '4.tmp', '.dot.tmp']);
 	t.deepEqual(deletedFiles, [
-		path.join(t.context.tmp, '4.tmp'),
+		path.join(t.context.tmp, '2.tmp'),
 		path.join(t.context.tmp, '3.tmp'),
-		path.join(t.context.tmp, '2.tmp')
+		path.join(t.context.tmp, '4.tmp')
 	]);
 });
 
@@ -131,10 +131,10 @@ test('does not throw EINVAL - async', async t => {
 		});
 
 		const expected = [
-			path.resolve(t.context.tmp, 'a/b/c/nested.js'),
-			path.resolve(t.context.tmp, 'a/b/c'),
+			path.resolve(t.context.tmp, 'a'),
 			path.resolve(t.context.tmp, 'a/b'),
-			path.resolve(t.context.tmp, 'a')
+			path.resolve(t.context.tmp, 'a/b/c'),
+			path.resolve(t.context.tmp, 'a/b/c/nested.js')
 		];
 
 		t.deepEqual(removed, expected);
@@ -165,10 +165,10 @@ test('does not throw EINVAL - sync', t => {
 		});
 
 		const expected = [
-			path.resolve(t.context.tmp, 'a/b/c/nested.js'),
-			path.resolve(t.context.tmp, 'a/b/c'),
+			path.resolve(t.context.tmp, 'a'),
 			path.resolve(t.context.tmp, 'a/b'),
-			path.resolve(t.context.tmp, 'a')
+			path.resolve(t.context.tmp, 'a/b/c'),
+			path.resolve(t.context.tmp, 'a/b/c/nested.js')
 		];
 
 		t.deepEqual(removed, expected);


### PR DESCRIPTION
#95 might be considered a breaking change since the files are sorted in reverse order. I am not sure this reverts the old order exactly, but thought I'd put this PR in to let you decide what's best.