### PR TITLE
Allow non-glob patterns with backslash on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ node_js:
   - '12'
   - '10'
   - '8'
+os:
+  - windows
+  - linux
+  - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
+os:
+  - linux
+  - osx
+  - windows
 language: node_js
 node_js:
   - '12'
   - '10'
   - '8'
-os:
-  - windows
-  - linux
-  - osx

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,12 +40,12 @@ declare const del: {
 	/**
 	Delete files and directories using glob patterns.
 
-	Note that glob patterns can only contain forward-slashes, not backward-slashes, so if you want to construct a glob pattern from path components, you need to use `path.posix.join()` instead of `path.join()`.
+	Note that glob patterns can only contain forward-slashes, not backward-slashes. Windows file paths can use backward-slashes as long as the path does not contain any glob-like characters, otherwise use `path.posix.join()` instead of `path.join()`.
 
 	@param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
 	- [Pattern examples with expected matches](https://github.com/sindresorhus/multimatch/blob/master/test/test.js)
 	- [Quick globbing pattern overview](https://github.com/sindresorhus/multimatch#globbing-patterns)
-	@param options - You can specify any of the [`globby` options](https://github.com/sindresorhus/globby#options) in addition to the `del` options. In constrast to the `globby` defaults, `expandDirectories`, `onlyFiles`, and `followSymbolicLinks` are `false` by default.
+	@param options - You can specify any of the [`globby` options](https://github.com/sindresorhus/globby#options) in addition to the `del` options. In contrast to the `globby` defaults, `expandDirectories`, `onlyFiles`, and `followSymbolicLinks` are `false` by default.
 	@returns The deleted paths.
 
 	@example
@@ -67,12 +67,12 @@ declare const del: {
 	/**
 	Synchronously delete files and directories using glob patterns.
 
-	Note that glob patterns can only contain forward-slashes, not backward-slashes, so if you want to construct a glob pattern from path components, you need to use `path.posix.join()` instead of `path.join()`.
+	Note that glob patterns can only contain forward-slashes, not backward-slashes. Windows file paths can use backward-slashes as long as the path does not contain any glob-like characters, otherwise use `path.posix.join()` instead of `path.join()`.
 
 	@param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
 	- [Pattern examples with expected matches](https://github.com/sindresorhus/multimatch/blob/master/test/test.js)
 	- [Quick globbing pattern overview](https://github.com/sindresorhus/multimatch#globbing-patterns)
-	@param options - You can specify any of the [`globby` options](https://github.com/sindresorhus/globby#options) in addition to the `del` options. In constrast to the `globby` defaults, `expandDirectories`, `onlyFiles`, and `followSymbolicLinks` are `false` by default.
+	@param options - You can specify any of the [`globby` options](https://github.com/sindresorhus/globby#options) in addition to the `del` options. In contrast to the `globby` defaults, `expandDirectories`, `onlyFiles`, and `followSymbolicLinks` are `false` by default.
 	@returns The deleted paths.
 	*/
 	sync(

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,8 +40,6 @@ declare const del: {
 	/**
 	Delete files and directories using glob patterns.
 
-	Note that glob patterns can only contain forward-slashes, not backward-slashes, so if you want to construct a glob pattern from path components, you need to use `path.posix.join()` instead of `path.join()`.
-
 	@param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
 	- [Pattern examples with expected matches](https://github.com/sindresorhus/multimatch/blob/master/test/test.js)
 	- [Quick globbing pattern overview](https://github.com/sindresorhus/multimatch#globbing-patterns)
@@ -66,8 +64,6 @@ declare const del: {
 
 	/**
 	Synchronously delete files and directories using glob patterns.
-
-	Note that glob patterns can only contain forward-slashes, not backward-slashes, so if you want to construct a glob pattern from path components, you need to use `path.posix.join()` instead of `path.join()`.
 
 	@param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
 	- [Pattern examples with expected matches](https://github.com/sindresorhus/multimatch/blob/master/test/test.js)

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,8 @@ declare const del: {
 	/**
 	Delete files and directories using glob patterns.
 
+	Note that glob patterns can only contain forward-slashes, not backward-slashes, so if you want to construct a glob pattern from path components, you need to use `path.posix.join()` instead of `path.join()`.
+
 	@param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
 	- [Pattern examples with expected matches](https://github.com/sindresorhus/multimatch/blob/master/test/test.js)
 	- [Quick globbing pattern overview](https://github.com/sindresorhus/multimatch#globbing-patterns)
@@ -64,6 +66,8 @@ declare const del: {
 
 	/**
 	Synchronously delete files and directories using glob patterns.
+
+	Note that glob patterns can only contain forward-slashes, not backward-slashes, so if you want to construct a glob pattern from path components, you need to use `path.posix.join()` instead of `path.join()`.
 
 	@param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
 	- [Pattern examples with expected matches](https://github.com/sindresorhus/multimatch/blob/master/test/test.js)

--- a/package.json
+++ b/package.json
@@ -45,10 +45,12 @@
 	],
 	"dependencies": {
 		"globby": "^10.0.0",
+		"is-glob": "^4.0.1",
 		"is-path-cwd": "^2.0.0",
 		"is-path-inside": "^3.0.1",
 		"p-map": "^2.0.0",
-		"rimraf": "^2.6.3"
+		"rimraf": "^2.6.3",
+		"slash": "^3.0.0"
 	},
 	"devDependencies": {
 		"ava": "^2.1.0",

--- a/readme.md
+++ b/readme.md
@@ -46,8 +46,6 @@ Suggestions on how to improve this welcome!
 
 ## API
 
-Note that glob patterns can only contain forward-slashes, not backward-slashes, so if you want to construct a glob pattern from path components, you need to use `path.posix.join()` instead of `path.join()`.
-
 ### del(patterns, options?)
 
 Returns `Promise<string[]>` with the deleted paths.

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,8 @@ Suggestions on how to improve this welcome!
 
 ## API
 
+Note that glob patterns can only contain forward-slashes, not backward-slashes, so if you want to construct a glob pattern from path components, you need to use `path.posix.join()` instead of `path.join()`.
+
 ### del(patterns, options?)
 
 Returns `Promise<string[]>` with the deleted paths.

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Suggestions on how to improve this welcome!
 
 ## API
 
-Note that glob patterns can only contain forward-slashes, not backward-slashes, so if you want to construct a glob pattern from path components, you need to use `path.posix.join()` instead of `path.join()`.
+Note that glob patterns can only contain forward-slashes, not backward-slashes. Windows file paths can use backward-slashes as long as the path does not contain any glob-like characters, otherwise use `path.posix.join()` instead of `path.join()`.
 
 ### del(patterns, options?)
 
@@ -69,7 +69,7 @@ See the supported [glob patterns](https://github.com/sindresorhus/globby#globbin
 
 Type: `object`
 
-You can specify any of the [`globby` options](https://github.com/sindresorhus/globby#options) in addition to the below options. In constrast to the `globby` defaults, `expandDirectories`, `onlyFiles`, and `followSymbolicLinks` are `false` by default.
+You can specify any of the [`globby` options](https://github.com/sindresorhus/globby#options) in addition to the below options. In contrast to the `globby` defaults, `expandDirectories`, `onlyFiles`, and `followSymbolicLinks` are `false` by default.
 
 ##### force
 

--- a/test.js
+++ b/test.js
@@ -317,59 +317,35 @@ test('cannot delete files inside process.cwd when outside cwd without force: tru
 });
 
 test('windows can pass absolute paths with "\\" - async', async t => {
-	const processPlatform = process.platform;
-	Object.defineProperty(process, 'platform', {value: 'win32'});
-
 	const filePath = path.resolve(t.context.tmp, '1.tmp');
-	const win32FilePath = path.win32.normalize(filePath);
 
-	const removeFiles = await del([win32FilePath], {cwd: t.context.tmp, dryRun: true});
+	const removeFiles = await del([filePath], {cwd: t.context.tmp, dryRun: true});
 
 	t.deepEqual(removeFiles, [filePath]);
-
-	Object.defineProperty(process, 'platform', {value: processPlatform});
 });
 
 test('windows can pass absolute paths with "\\" - sync', t => {
-	const processPlatform = process.platform;
-	Object.defineProperty(process, 'platform', {value: 'win32'});
-
 	const filePath = path.resolve(t.context.tmp, '1.tmp');
-	const win32FilePath = path.win32.normalize(filePath);
 
-	const removeFiles = del.sync([win32FilePath], {cwd: t.context.tmp, dryRun: true});
+	const removeFiles = del.sync([filePath], {cwd: t.context.tmp, dryRun: true});
 
 	t.deepEqual(removeFiles, [filePath]);
-
-	Object.defineProperty(process, 'platform', {value: processPlatform});
 });
 
 test('windows can pass relative paths with "\\" - async', async t => {
 	const nestedFile = path.resolve(t.context.tmp, 'a/b/c/nested.js');
 	makeDir.sync(nestedFile);
 
-	const processPlatform = process.platform;
-	Object.defineProperty(process, 'platform', {value: 'win32'});
-
-	const win32FilePath = path.win32.normalize(nestedFile);
-	const removeFiles = await del([win32FilePath], {cwd: t.context.tmp, dryRun: true});
+	const removeFiles = await del([nestedFile], {cwd: t.context.tmp, dryRun: true});
 
 	t.deepEqual(removeFiles, [nestedFile]);
-
-	Object.defineProperty(process, 'platform', {value: processPlatform});
 });
 
 test('windows can pass relative paths with "\\" - sync', t => {
 	const nestedFile = path.resolve(t.context.tmp, 'a/b/c/nested.js');
 	makeDir.sync(nestedFile);
 
-	const processPlatform = process.platform;
-	Object.defineProperty(process, 'platform', {value: 'win32'});
-
-	const win32FilePath = path.win32.normalize(nestedFile);
-	const removeFiles = del.sync([win32FilePath], {cwd: t.context.tmp, dryRun: true});
+	const removeFiles = del.sync([nestedFile], {cwd: t.context.tmp, dryRun: true});
 
 	t.deepEqual(removeFiles, [nestedFile]);
-
-	Object.defineProperty(process, 'platform', {value: processPlatform});
 });

--- a/test.js
+++ b/test.js
@@ -315,3 +315,61 @@ test('cannot delete files inside process.cwd when outside cwd without force: tru
 	exists(t, ['1.tmp', '2.tmp', '3.tmp', '4.tmp', '.dot.tmp']);
 	process.chdir(processCwd);
 });
+
+test('windows can pass absolute paths with "\\" - async', async t => {
+	const processPlatform = process.platform;
+	Object.defineProperty(process, 'platform', {value: 'win32'});
+
+	const filePath = path.resolve(t.context.tmp, '1.tmp');
+	const win32FilePath = path.win32.normalize(filePath);
+
+	const removeFiles = await del([win32FilePath], {cwd: t.context.tmp, dryRun: true});
+
+	t.deepEqual(removeFiles, [filePath]);
+
+	Object.defineProperty(process, 'platform', {value: processPlatform});
+});
+
+test('windows can pass absolute paths with "\\" - sync', t => {
+	const processPlatform = process.platform;
+	Object.defineProperty(process, 'platform', {value: 'win32'});
+
+	const filePath = path.resolve(t.context.tmp, '1.tmp');
+	const win32FilePath = path.win32.normalize(filePath);
+
+	const removeFiles = del.sync([win32FilePath], {cwd: t.context.tmp, dryRun: true});
+
+	t.deepEqual(removeFiles, [filePath]);
+
+	Object.defineProperty(process, 'platform', {value: processPlatform});
+});
+
+test('windows can pass relative paths with "\\" - async', async t => {
+	const nestedFile = path.resolve(t.context.tmp, 'a/b/c/nested.js');
+	makeDir.sync(nestedFile);
+
+	const processPlatform = process.platform;
+	Object.defineProperty(process, 'platform', {value: 'win32'});
+
+	const win32FilePath = path.win32.normalize(nestedFile);
+	const removeFiles = await del([win32FilePath], {cwd: t.context.tmp, dryRun: true});
+
+	t.deepEqual(removeFiles, [nestedFile]);
+
+	Object.defineProperty(process, 'platform', {value: processPlatform});
+});
+
+test('windows can pass relative paths with "\\" - sync', t => {
+	const nestedFile = path.resolve(t.context.tmp, 'a/b/c/nested.js');
+	makeDir.sync(nestedFile);
+
+	const processPlatform = process.platform;
+	Object.defineProperty(process, 'platform', {value: 'win32'});
+
+	const win32FilePath = path.win32.normalize(nestedFile);
+	const removeFiles = del.sync([win32FilePath], {cwd: t.context.tmp, dryRun: true});
+
+	t.deepEqual(removeFiles, [nestedFile]);
+
+	Object.defineProperty(process, 'platform', {value: processPlatform});
+});


### PR DESCRIPTION
This PR reverts the breaking change in `5.0.0` not allowing windows to pass direct paths to del making del easier to use on windows.

Fixes #105 