### PR TITLE
Sort removed files

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = async (patterns, {force, dryRun, cwd = process.cwd(), ...option
 
 	const removedFiles = await pMap(files, mapper, options);
 
-	removedFiles.reverse();
+	removedFiles.sort((a, b) => a.localeCompare(b));
 
 	return removedFiles;
 };
@@ -78,7 +78,7 @@ module.exports.sync = (patterns, {force, dryRun, cwd = process.cwd(), ...options
 		return file;
 	});
 
-	removedFiles.reverse();
+	removedFiles.sort((a, b) => a.localeCompare(b));
 
 	return removedFiles;
 };


### PR DESCRIPTION
> https://github.com/sindresorhus/del/pull/99#issuecomment-511160977 After thinking about this comment I think this PR should be updated to use .sort((a, b) => a.localeCompare(b)) instead of .reverse() to consistently return the same order every time.
