### PR TITLE
Closes: #138 - Update index.js

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,84 +1,61 @@
-import {GlobbyOptions} from 'globby';
-
-declare namespace del {
-	interface Options extends GlobbyOptions {
-		/**
-		Allow deleting the current working directory and outside.
-
-		@default false
-		*/
-		readonly force?: boolean;
-
-		/**
-		See what would be deleted.
-
-		@default false
-
-		@example
-		```
-		import del = require('del');
-
-		(async () => {
-			const deletedPaths = await del(['temp/*.js'], {dryRun: true});
-
-			console.log('Files and directories that would be deleted:\n', deletedPaths.join('\n'));
-		})();
-		```
-		*/
-		readonly dryRun?: boolean;
-
-		/**
-		Concurrency limit. Minimum: `1`.
-
-		@default Infinity
-		*/
-		readonly concurrency?: number;
-	}
+// v13.1.1 export type GlobbyOptions = import('globby').Options;
+export type GlobbyOptions = import('globby').GlobbyOptions;
+export interface delOptionPropertys {
+	/**
+	 * default false
+	 */
+	force?: boolean;
+	/**
+	 * default false
+	 */
+	dryRun?: boolean;
+	/**
+	 * default false
+	 */
+	cwd?: string;
 }
+export type delOptions = delOptionPropertys & GlobbyOptions;
+export type patterns = string | readonly string[];
 
-declare const del: {
-	/**
-	Synchronously delete files and directories using glob patterns.
-
-	Note that glob patterns can only contain forward-slashes, not backward-slashes. Windows file paths can use backward-slashes as long as the path does not contain any glob-like characters, otherwise use `path.posix.join()` instead of `path.join()`.
-
-	@param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
-	- [Pattern examples with expected matches](https://github.com/sindresorhus/multimatch/blob/main/test/test.js)
-	- [Quick globbing pattern overview](https://github.com/sindresorhus/multimatch#globbing-patterns)
-	@param options - You can specify any of the [`globby` options](https://github.com/sindresorhus/globby#options) in addition to the `del` options. In contrast to the `globby` defaults, `expandDirectories`, `onlyFiles`, and `followSymbolicLinks` are `false` by default.
-	@returns The deleted paths.
-	*/
-	sync: (
-		patterns: string | readonly string[],
-		options?: del.Options
-	) => string[];
-
-	/**
-	Delete files and directories using glob patterns.
-
-	Note that glob patterns can only contain forward-slashes, not backward-slashes. Windows file paths can use backward-slashes as long as the path does not contain any glob-like characters, otherwise use `path.posix.join()` instead of `path.join()`.
-
-	@param patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
-	- [Pattern examples with expected matches](https://github.com/sindresorhus/multimatch/blob/main/test/test.js)
-	- [Quick globbing pattern overview](https://github.com/sindresorhus/multimatch#globbing-patterns)
-	@param options - You can specify any of the [`globby` options](https://github.com/sindresorhus/globby#options) in addition to the `del` options. In contrast to the `globby` defaults, `expandDirectories`, `onlyFiles`, and `followSymbolicLinks` are `false` by default.
-	@returns The deleted paths.
-
-	@example
-	```
-	import del = require('del');
-
-	(async () => {
-		const deletedPaths = await del(['temp/*.js', '!temp/unicorn.js']);
-
-		console.log('Deleted files and directories:\n', deletedPaths.join('\n'));
-	})();
-	```
-	*/
-	(
-		patterns: string | readonly string[],
-		options?: del.Options
-	): Promise<string[]>;
-};
-
-export = del;
+/**
+ * Synchronously delete files and directories using glob patterns.
+ * Note that glob patterns can only contain forward-slashes, not
+ * backward-slashes. Windows file paths can use backward-slashes
+ * as long as the path does not contain any glob-like characters,
+ * otherwise use `path.posix.join()` instead of `path.join()`.
+ * @param {patterns} patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
+ *	- [Pattern examples with expected matches](https://github.com/sindresorhus/multimatch/blob/main/test/test.js)
+ *	- [Quick globbing pattern overview](https://github.com/sindresorhus/multimatch#globbing-patterns)
+ * @param {delOptions} delOptions - You can specify any of the
+ * [`globby` options](https://github.com/sindresorhus/globby#options) in addition to the `delOptions`. In contrast to the `globby` defaults, `expandDirectories`, `onlyFiles`, and `followSymbolicLinks` are `false` by default.
+ * @returns {string[]} The deleted paths.
+ * @example
+ * ```
+ * import { delSync } from 'del';
+ * console.log('Deleted files and directories:\n', delSync(['temp/*.js', '!temp/unicorn.js']).join('\n'));
+ * ```
+ */
+export function delSync(patterns: patterns, delOptions: delOptions): string[];
+/**
+ * delete files and directories using glob patterns.
+ * Note that glob patterns can only contain forward-slashes, not
+ * backward-slashes. Windows file paths can use backward-slashes
+ * as long as the path does not contain any glob-like characters,
+ * otherwise use `path.posix.join()` instead of `path.join()`.
+ * @param {patterns} patterns - See the supported [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
+ *	- [Pattern examples with expected matches](https://github.com/sindresorhus/multimatch/blob/main/test/test.js)
+ *	- [Quick globbing pattern overview](https://github.com/sindresorhus/multimatch#globbing-patterns)
+ * @param {delOptions} delOptions - You can specify any of the
+ * [`globby` options](https://github.com/sindresorhus/globby#options) in addition to the `delOptions`. In contrast to the `globby` defaults, `expandDirectories`, `onlyFiles`, and `followSymbolicLinks` are `false` by default.
+ * @returns {Promise<string[]>} The deleted paths.
+ * @example
+ * ```
+ * import { delAsync } from 'del';
+ * const deleteAndLogPathes = async (pathesToDelete) => {
+ *	const deletedPaths = await del(pathesToDelete);
+ *	console.log('Deleted files and directories:\n', deletedPaths.join('\n'));
+ * };
+ * deleteAndLogPathes(['temp/*.js', '!temp/unicorn.js']);
+ * ```
+ */
+export function delAsync(patterns: patterns, delOptions: delOptions): Promise<string[]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,7 @@ export type patterns = string | readonly string[];
  * @returns {string[]} The deleted paths.
  * @example
  * ```
- * import { delSync } from 'del';
+ * const { delSync } = require('del');
  * console.log('Deleted files and directories:\n', delSync(['temp/*.js', '!temp/unicorn.js']).join('\n'));
  * ```
  */
@@ -50,7 +50,7 @@ export function delSync(patterns: patterns, delOptions: delOptions): string[];
  * @returns {Promise<string[]>} The deleted paths.
  * @example
  * ```
- * import { delAsync } from 'del';
+ * const { delAsync } = require('del');
  * const deleteAndLogPathes = async (pathesToDelete) => {
  *	const deletedPaths = await del(pathesToDelete);
  *	console.log('Deleted files and directories:\n', deletedPaths.join('\n'));

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
-const {promisify} = require('util');
+const { promisify } = require('util');
 const path = require('path');
+
 const globby = require('globby');
 const isGlob = require('is-glob');
 const slash = require('slash');
@@ -13,109 +14,128 @@ const pMap = require('p-map');
 const rimrafP = promisify(rimraf);
 
 const rimrafOptions = {
-	glob: false,
-	unlink: gracefulFs.unlink,
-	unlinkSync: gracefulFs.unlinkSync,
-	chmod: gracefulFs.chmod,
-	chmodSync: gracefulFs.chmodSync,
-	stat: gracefulFs.stat,
-	statSync: gracefulFs.statSync,
-	lstat: gracefulFs.lstat,
-	lstatSync: gracefulFs.lstatSync,
-	rmdir: gracefulFs.rmdir,
-	rmdirSync: gracefulFs.rmdirSync,
-	readdir: gracefulFs.readdir,
-	readdirSync: gracefulFs.readdirSync
+  glob: false,
+  unlink: gracefulFs.unlink,
+  unlinkSync: gracefulFs.unlinkSync,
+  chmod: gracefulFs.chmod,
+  chmodSync: gracefulFs.chmodSync,
+  stat: gracefulFs.stat,
+  statSync: gracefulFs.statSync,
+  lstat: gracefulFs.lstat,
+  lstatSync: gracefulFs.lstatSync,
+  rmdir: gracefulFs.rmdir,
+  rmdirSync: gracefulFs.rmdirSync,
+  readdir: gracefulFs.readdir,
+  readdirSync: gracefulFs.readdirSync
 };
 
 function safeCheck(file, cwd) {
-	if (isPathCwd(file)) {
-		throw new Error('Cannot delete the current working directory. Can be overridden with the `force` option.');
-	}
+  if (isPathCwd(file)) {
+    throw new Error(
+      'Cannot delete the current working directory. Can be overridden with the `force` option.'
+    );
+  }
 
-	if (!isPathInside(file, cwd)) {
-		throw new Error('Cannot delete files/directories outside the current working directory. Can be overridden with the `force` option.');
-	}
+  if (!isPathInside(file, cwd)) {
+    throw new Error(
+      'Cannot delete files/directories outside the current working directory. Can be overridden with the `force` option.'
+    );
+  }
 }
 
 function normalizePatterns(patterns) {
-	patterns = Array.isArray(patterns) ? patterns : [patterns];
+  patterns = Array.isArray(patterns) ? patterns : [patterns];
 
-	patterns = patterns.map(pattern => {
-		if (process.platform === 'win32' && isGlob(pattern) === false) {
-			return slash(pattern);
-		}
+  patterns = patterns.map((pattern) => {
+    if (process.platform === 'win32' && isGlob(pattern) === false) {
+      return slash(pattern);
+    }
 
-		return pattern;
-	});
+    return pattern;
+  });
 
-	return patterns;
+  return patterns;
 }
 
-module.exports = async (patterns, {force, dryRun, cwd = process.cwd(), ...options} = {}) => {
-	options = {
-		expandDirectories: false,
-		onlyFiles: false,
-		followSymbolicLinks: false,
-		cwd,
-		...options
-	};
+/**
+ * @typedef {import('globby').GlobbyOptions} GlobbyOptions //  Globby 13.1.1 version @ typedef {import('globby').Options} GlobbyOptions
+ * @typedef delOptionPropertys
+ * @property {boolean} [force] default false
+ * @property {boolean} [dryRun] default false
+ * @property {string} [cwd] default false
+ * @typedef {delOptionPropertys & GlobbyOptions} delOptions
+ * @typedef {string | readonly string[]} patterns
+ * @typedef {typeof delAsync & { sync: typeof delSync }} deprecatedCjsCompatModuleObject
+ */
+const normalizeDelOptions = (/** @type {delOptions} */ delOptions) => {
+  const { force = false, dryRun = false, cwd = process.cwd(), ...inputGlobbyOptions } = delOptions;
 
-	patterns = normalizePatterns(patterns);
-
-	const files = (await globby(patterns, options))
-		.sort((a, b) => b.localeCompare(a));
-
-	const mapper = async file => {
-		file = path.resolve(cwd, file);
-
-		if (!force) {
-			safeCheck(file, cwd);
-		}
-
-		if (!dryRun) {
-			await rimrafP(file, rimrafOptions);
-		}
-
-		return file;
-	};
-
-	const removedFiles = await pMap(files, mapper, options);
-
-	removedFiles.sort((a, b) => a.localeCompare(b));
-
-	return removedFiles;
+  /** @type {GlobbyOptions} */
+  const globbyOptions = {
+    expandDirectories: false,
+    onlyFiles: false,
+    followSymbolicLinks: false,
+    cwd,
+    ...inputGlobbyOptions
+  };
+  return { force, dryRun, cwd, globbyOptions };
 };
 
-module.exports.sync = (patterns, {force, dryRun, cwd = process.cwd(), ...options} = {}) => {
-	options = {
-		expandDirectories: false,
-		onlyFiles: false,
-		followSymbolicLinks: false,
-		cwd,
-		...options
-	};
+const delAsync = async (patterns, delOptions) => {
+  const { force, dryRun, cwd, globbyOptions: options } = normalizeDelOptions(delOptions);
 
-	patterns = normalizePatterns(patterns);
+  patterns = normalizePatterns(patterns);
 
-	const files = globby.sync(patterns, options)
-		.sort((a, b) => b.localeCompare(a));
+  const files = (await globby(patterns, options)).sort((a, b) => b.localeCompare(a));
 
-	const removedFiles = files.map(file => {
-		file = path.resolve(cwd, file);
+  const mapper = async (file) => {
+    file = path.resolve(cwd, file);
 
-		if (!force) {
-			safeCheck(file, cwd);
-		}
+    if (!force) {
+      safeCheck(file, cwd);
+    }
 
-		if (!dryRun) {
-			rimraf.sync(file, rimrafOptions);
-		}
+    if (!dryRun) {
+      await rimrafP(file, rimrafOptions);
+    }
 
-		return file;
-	});
+    return file;
+  };
 
-	removedFiles.sort((a, b) => a.localeCompare(b));
+  const removedFiles = await pMap(files, mapper, options);
 
-	return removedFiles;
+  removedFiles.sort((a, b) => a.localeCompare(b));
+
+  return removedFiles;
 };
+
+const delSync = (patterns, delOptions) => {
+  const { force, dryRun, cwd, globbyOptions: options } = normalizeDelOptions(delOptions);
+
+  patterns = normalizePatterns(patterns);
+
+  const files = globby.sync(patterns, options).sort((a, b) => b.localeCompare(a));
+
+  const removedFiles = files.map((file) => {
+    file = path.resolve(cwd, file);
+
+    if (!force) {
+      safeCheck(file, cwd);
+    }
+
+    if (!dryRun) {
+      rimraf.sync(file, rimrafOptions);
+    }
+
+    return file;
+  });
+
+  removedFiles.sort((a, b) => a.localeCompare(b));
+
+  return removedFiles;
+};
+
+exports.delAsync = delAsync;
+exports.delSync = delSync;
+
+module.exports = Object.assign(() => {}, delAsync, exports, { sync: delSync });


### PR DESCRIPTION
Introduces delAsync and delSync for later esm conversation

Compat with the old v6.0.0 API
Update now all Examples to const { delAsync, delSync } = require('del');
Leads to later import { delAsync, delSync } from 'del';
see: https://github.com/sindresorhus/del/issues/138