### PR TITLE
Cjs globby v13 esm

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {GlobbyOptions} from 'globby';
+import {Options as GlobbyOptions} from 'globby';
 
 declare namespace del {
 	interface Options extends GlobbyOptions {
@@ -51,7 +51,7 @@ declare const del: {
 	sync: (
 		patterns: string | readonly string[],
 		options?: del.Options
-	) => string[];
+	) => Promise<string[]>;
 
 	/**
 	Delete files and directories using glob patterns.

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = async (patterns, {force, dryRun, cwd = process.cwd(), ...option
 
 	patterns = normalizePatterns(patterns);
 
-	const files = (await globby(patterns, options))
+	const files = (await import('globby')).globby(patterns, options))
 		.sort((a, b) => b.localeCompare(a));
 
 	const mapper = async file => {
@@ -87,7 +87,7 @@ module.exports = async (patterns, {force, dryRun, cwd = process.cwd(), ...option
 	return removedFiles;
 };
 
-module.exports.sync = (patterns, {force, dryRun, cwd = process.cwd(), ...options} = {}) => {
+module.exports.sync = async (patterns, {force, dryRun, cwd = process.cwd(), ...options} = {}) => {
 	options = {
 		expandDirectories: false,
 		onlyFiles: false,
@@ -98,7 +98,7 @@ module.exports.sync = (patterns, {force, dryRun, cwd = process.cwd(), ...options
 
 	patterns = normalizePatterns(patterns);
 
-	const files = globby.sync(patterns, options)
+	const files = (await import('globby')).globbySync(patterns, options)
 		.sort((a, b) => b.localeCompare(a));
 
 	const removedFiles = files.map(file => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "del",
-	"version": "6.0.0",
+	"version": "6.1.0",
 	"description": "Delete files and directories",
 	"license": "MIT",
 	"repository": "sindresorhus/del",
@@ -46,7 +46,7 @@
 		"filesystem"
 	],
 	"dependencies": {
-		"globby": "^11.0.1",
+		"globby": "^13.1.1",
 		"graceful-fs": "^4.2.4",
 		"is-glob": "^4.0.1",
 		"is-path-cwd": "^2.2.0",


### PR DESCRIPTION
I Issue this PR only to discusse that with you in issue #138 

## Conclusion 
because of this pull request that changes the api of sync as it now would return a Promise<string[]>

## Two choices
- we bundle globby v13 as cjs code  i would at present not want that
- we skip that and only merge the api upgrade and after that directly v7 esm only with globby 13 what do you think?