### PR TITLE
Document `dot` option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -101,18 +101,24 @@ console.log('Files and directories that would be deleted:\n', deletedPaths.join(
 Type: `boolean`\
 Default: `false`
 
-Allow patterns to match files/folders that begin with a period (`.`). This option is passed through to [fast-glob](https://github.com/mrmlnc/fast-glob#dot).
+Allow patterns to match files/folders that start with a period (`.`).
 
-> :book: Note that an explicit dot in a portion of the pattern will always match dot files.
-```plain
-dir/
+This option is passed through to [`fast-glob`](https://github.com/mrmlnc/fast-glob#dot).
+
+> Note that an explicit dot in a portion of the pattern will always match dot files.
+```
+directory/
 ├── .editorconfig
 └── package.json
 ```
 
 ```js
-deleteSync('*', { dot: false }); // ['package.json']
-deleteSync('*', { dot: true });  // ['.editorconfig', 'package.json']
+import {deleteSync} from 'del';
+
+deleteSync('*', {dot: false});
+//=> ['package.json']
+deleteSync('*', {dot: true});
+//=> ['.editorconfig', 'package.json']
 ```
 
 ##### concurrency

--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,19 @@ console.log('Files and directories that would be deleted:\n', deletedPaths.join(
 Type: `boolean`\
 Default: `false`
 
-Causes `*` to treat files beginning with a `.` character like any other file. If `false`, dot files will not be matched by `*`. Alternately, `.*` can be used to match dot files. This option is passed through to [`glob`](https://github.com/isaacs/node-glob#dots).
+Allow patterns to match files/folders that begin with a period (`.`). This option is passed through to [fast-glob](https://github.com/mrmlnc/fast-glob#dot).
+
+> :book: Note that an explicit dot in a portion of the pattern will always match dot files.
+```plain
+dir/
+├── .editorconfig
+└── package.json
+```
+
+```js
+deleteSync('*', { dot: false }); // ['package.json']
+deleteSync('*', { dot: true });  // ['.editorconfig', 'package.json']
+```
 
 ##### concurrency
 

--- a/readme.md
+++ b/readme.md
@@ -105,7 +105,10 @@ Allow patterns to match files/folders that start with a period (`.`).
 
 This option is passed through to [`fast-glob`](https://github.com/mrmlnc/fast-glob#dot).
 
-> Note that an explicit dot in a portion of the pattern will always match dot files.
+Note that an explicit dot in a portion of the pattern will always match dot files.
+
+**Example**
+
 ```
 directory/
 ├── .editorconfig

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,13 @@ const deletedPaths = await deleteAsync(['temp/*.js'], {dryRun: true});
 console.log('Files and directories that would be deleted:\n', deletedPaths.join('\n'));
 ```
 
+##### dot
+
+Type: `boolean`\
+Default: `false`
+
+Delete dot files (files starting with a `.`). This option is passed through to [`glob`](https://github.com/isaacs/node-glob#dots).
+
 ##### concurrency
 
 Type: `number`\

--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,7 @@ console.log('Files and directories that would be deleted:\n', deletedPaths.join(
 Type: `boolean`\
 Default: `false`
 
-Delete dot files (files starting with a `.`). This option is passed through to [`glob`](https://github.com/isaacs/node-glob#dots).
+Causes `*` to treat files beginning with a `.` character like any other file. If `false`, dot files will not be matched by `*`. Alternately, `.*` can be used to match dot files. This option is passed through to [`glob`](https://github.com/isaacs/node-glob#dots).
 
 ##### concurrency
 


### PR DESCRIPTION
Resolves https://github.com/sindresorhus/del/issues/38#issuecomment-752880161

If the bit about:
>This option is passed through to [`glob`](https://github.com/isaacs/node-glob#dots).

... Isn't accurate, happy to remove that part. That was my best guess after poking around the deps and checking https://npmgraph.js.org/?q=del.