### PR TITLE
chore: update dependencies and require node 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,16 +10,16 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 22
           - 20
           - 18
-          - 16
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,7 +1,7 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import Benchmark from 'benchmark';
-import {makeDirectorySync} from 'make-dir';
 import {temporaryDirectory} from 'tempy';
 import {deleteAsync, deleteSync} from './index.js';
 
@@ -13,7 +13,7 @@ const fixtures = Array.from({length: 2000}, (_, index) => path.resolve(temporary
 
 function createFixtures() {
 	for (const fixture of fixtures) {
-		makeDirectorySync(path.resolve(temporaryDirectoryPath, fixture));
+		fs.mkdirSync(path.resolve(temporaryDirectoryPath, fixture), {recursive: true});
 	}
 }
 

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import process from 'node:process';
 import Benchmark from 'benchmark';
-import makeDir from 'make-dir';
+import {makeDirectorySync} from 'make-dir';
 import {temporaryDirectory} from 'tempy';
 import {deleteAsync, deleteSync} from './index.js';
 
@@ -13,7 +13,7 @@ const fixtures = Array.from({length: 2000}, (_, index) => path.resolve(temporary
 
 function createFixtures() {
 	for (const fixture of fixtures) {
-		makeDir.sync(path.resolve(temporaryDirectoryPath, fixture));
+		makeDirectorySync(path.resolve(temporaryDirectoryPath, fixture));
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import {globby, globbySync} from 'globby';
@@ -63,7 +65,7 @@ export async function deleteAsync(patterns, {force, dryRun, cwd = process.cwd(),
 		}
 
 		if (!dryRun) {
-			await fs.rmSync(file, {recursive: true, force: true});
+			await fsPromises.rm(file, {recursive: true, force: true});
 		}
 
 		deletedCount += 1;

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ export async function deleteAsync(patterns, {force, dryRun, cwd = process.cwd(),
 		}
 
 		if (!dryRun) {
-			await rimraf(file, rimrafOptions);
+			await fs.rmSync(file, { recursive: true, force: true });
 		}
 
 		deletedCount += 1;

--- a/index.js
+++ b/index.js
@@ -2,11 +2,11 @@ import path from 'node:path';
 import process from 'node:process';
 import {globby, globbySync} from 'globby';
 import isGlob from 'is-glob';
-import slash from 'slash';
 import isPathCwd from 'is-path-cwd';
 import isPathInside from 'is-path-inside';
-import {rimraf} from 'rimraf';
 import pMap from 'p-map';
+import {rimraf} from 'rimraf';
+import slash from 'slash';
 
 const rimrafOptions = {
 	glob: false,

--- a/index.js
+++ b/index.js
@@ -5,12 +5,7 @@ import isGlob from 'is-glob';
 import isPathCwd from 'is-path-cwd';
 import isPathInside from 'is-path-inside';
 import pMap from 'p-map';
-import {rimraf} from 'rimraf';
 import slash from 'slash';
-
-const rimrafOptions = {
-	glob: false,
-};
 
 function safeCheck(file, cwd) {
 	if (isPathCwd(file)) {
@@ -68,7 +63,7 @@ export async function deleteAsync(patterns, {force, dryRun, cwd = process.cwd(),
 		}
 
 		if (!dryRun) {
-			await fs.rmSync(file, { recursive: true, force: true });
+			await fs.rmSync(file, {recursive: true, force: true});
 		}
 
 		deletedCount += 1;
@@ -112,7 +107,7 @@ export function deleteSync(patterns, {force, dryRun, cwd = process.cwd(), ...opt
 		}
 
 		if (!dryRun) {
-			rimraf.sync(file, rimrafOptions);
+			fs.rmSync(file, {recursive: true, force: true});
 		}
 
 		return file;

--- a/index.js
+++ b/index.js
@@ -1,31 +1,15 @@
-import {promisify} from 'node:util';
 import path from 'node:path';
 import process from 'node:process';
 import {globby, globbySync} from 'globby';
 import isGlob from 'is-glob';
 import slash from 'slash';
-import gracefulFs from 'graceful-fs';
 import isPathCwd from 'is-path-cwd';
 import isPathInside from 'is-path-inside';
-import rimraf from 'rimraf';
+import {rimraf} from 'rimraf';
 import pMap from 'p-map';
-
-const rimrafP = promisify(rimraf);
 
 const rimrafOptions = {
 	glob: false,
-	unlink: gracefulFs.unlink,
-	unlinkSync: gracefulFs.unlinkSync,
-	chmod: gracefulFs.chmod,
-	chmodSync: gracefulFs.chmodSync,
-	stat: gracefulFs.stat,
-	statSync: gracefulFs.statSync,
-	lstat: gracefulFs.lstat,
-	lstatSync: gracefulFs.lstatSync,
-	rmdir: gracefulFs.rmdir,
-	rmdirSync: gracefulFs.rmdirSync,
-	readdir: gracefulFs.readdir,
-	readdirSync: gracefulFs.readdirSync,
 };
 
 function safeCheck(file, cwd) {
@@ -84,7 +68,7 @@ export async function deleteAsync(patterns, {force, dryRun, cwd = process.cwd(),
 		}
 
 		if (!dryRun) {
-			await rimrafP(file, rimrafOptions);
+			await rimraf(file, rimrafOptions);
 		}
 
 		deletedCount += 1;

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
 	"devDependencies": {
 		"ava": "^6.1.3",
 		"benchmark": "^2.1.4",
-		"make-dir": "^5.0.0",
 		"tempy": "^3.1.0",
 		"tsd": "^0.31.0",
 		"xo": "^0.58.0"
@@ -68,10 +67,5 @@
 	"ava": {
 		"serial": true,
 		"workerThreads": false
-	},
-	"xo": {
-		"rules": {
-			"unicorn/prefer-string-replace-all": "off"
-		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"exports": "./index.js",
 	"types": "./index.d.ts",
 	"engines": {
-		"node": ">=14.16"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd",
@@ -49,22 +49,21 @@
 		"filesystem"
 	],
 	"dependencies": {
-		"globby": "^13.1.2",
-		"graceful-fs": "^4.2.10",
+		"globby": "^14.0.1",
 		"is-glob": "^4.0.3",
 		"is-path-cwd": "^3.0.0",
 		"is-path-inside": "^4.0.0",
-		"p-map": "^5.5.0",
-		"rimraf": "^3.0.2",
-		"slash": "^4.0.0"
+		"p-map": "^7.0.2",
+		"rimraf": "^5.0.7",
+		"slash": "^5.1.0"
 	},
 	"devDependencies": {
-		"ava": "^4.3.1",
+		"ava": "^6.1.3",
 		"benchmark": "^2.1.4",
-		"make-dir": "^3.1.0",
-		"tempy": "^3.0.0",
-		"tsd": "^0.22.0",
-		"xo": "^0.56.0"
+		"make-dir": "^5.0.0",
+		"tempy": "^3.1.0",
+		"tsd": "^0.31.0",
+		"xo": "^0.58.0"
 	},
 	"ava": {
 		"serial": true,

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
-import {fileURLToPath} from 'node:url';
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import {fileURLToPath} from 'node:url';
 import test from 'ava';
 import {temporaryDirectory} from 'tempy';
 import {deleteAsync, deleteSync} from './index.js';

--- a/test.js
+++ b/test.js
@@ -4,7 +4,6 @@ import path from 'node:path';
 import process from 'node:process';
 import test from 'ava';
 import {temporaryDirectory} from 'tempy';
-import {makeDirectorySync} from 'make-dir';
 import {deleteAsync, deleteSync} from './index.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -34,7 +33,7 @@ test.beforeEach(t => {
 	t.context.tmp = temporaryDirectory();
 
 	for (const fixture of fixtures) {
-		makeDirectorySync(path.join(t.context.tmp, fixture));
+		fs.mkdirSync(path.join(t.context.tmp, fixture), {recursive: true});
 	}
 });
 
@@ -125,7 +124,7 @@ test('does not throw EINVAL - async', async t => {
 
 	let count = 0;
 	while (count !== totalAttempts) {
-		makeDirectorySync(nestedFile);
+		fs.mkdirSync(nestedFile, {recursive: true});
 
 		// eslint-disable-next-line no-await-in-loop
 		const removed = await deleteAsync('**/*', {
@@ -160,7 +159,7 @@ test('does not throw EINVAL - sync', t => {
 
 	let count = 0;
 	while (count !== totalAttempts) {
-		makeDirectorySync(nestedFile);
+		fs.mkdirSync(nestedFile, {recursive: true});
 
 		const removed = deleteSync('**/*', {
 			cwd: t.context.tmp,
@@ -337,7 +336,7 @@ test('windows can pass absolute paths with "\\" - sync', t => {
 
 test('windows can pass relative paths with "\\" - async', async t => {
 	const nestedFile = path.resolve(t.context.tmp, 'a/b/c/nested.js');
-	makeDirectorySync(nestedFile);
+	fs.mkdirSync(nestedFile, {recursive: true});
 
 	const removeFiles = await deleteAsync([nestedFile], {cwd: t.context.tmp, dryRun: true});
 
@@ -346,7 +345,7 @@ test('windows can pass relative paths with "\\" - async', async t => {
 
 test('windows can pass relative paths with "\\" - sync', t => {
 	const nestedFile = path.resolve(t.context.tmp, 'a/b/c/nested.js');
-	makeDirectorySync(nestedFile);
+	fs.mkdirSync(nestedFile, {recursive: true});
 
 	const removeFiles = deleteSync([nestedFile], {cwd: t.context.tmp, dryRun: true});
 
@@ -389,7 +388,7 @@ test('onProgress option - progress of single file', async t => {
 test('onProgress option - progress of multiple files', async t => {
 	const reports = [];
 
-	const sourcePath = process.platform === 'win32' ? path.resolve(`${t.context.tmp}/*`).replace(/\\/g, '/') : `${t.context.tmp}/*`;
+	const sourcePath = process.platform === 'win32' ? path.resolve(`${t.context.tmp}/*`).replaceAll('\\', '/') : `${t.context.tmp}/*`;
 
 	await deleteAsync(sourcePath, {
 		cwd: __dirname,

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ import path from 'node:path';
 import process from 'node:process';
 import test from 'ava';
 import {temporaryDirectory} from 'tempy';
-import makeDir from 'make-dir';
+import {makeDirectorySync} from 'make-dir';
 import {deleteAsync, deleteSync} from './index.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -34,7 +34,7 @@ test.beforeEach(t => {
 	t.context.tmp = temporaryDirectory();
 
 	for (const fixture of fixtures) {
-		makeDir.sync(path.join(t.context.tmp, fixture));
+		makeDirectorySync(path.join(t.context.tmp, fixture));
 	}
 });
 
@@ -125,7 +125,7 @@ test('does not throw EINVAL - async', async t => {
 
 	let count = 0;
 	while (count !== totalAttempts) {
-		makeDir.sync(nestedFile);
+		makeDirectorySync(nestedFile);
 
 		// eslint-disable-next-line no-await-in-loop
 		const removed = await deleteAsync('**/*', {
@@ -160,7 +160,7 @@ test('does not throw EINVAL - sync', t => {
 
 	let count = 0;
 	while (count !== totalAttempts) {
-		makeDir.sync(nestedFile);
+		makeDirectorySync(nestedFile);
 
 		const removed = deleteSync('**/*', {
 			cwd: t.context.tmp,
@@ -337,7 +337,7 @@ test('windows can pass absolute paths with "\\" - sync', t => {
 
 test('windows can pass relative paths with "\\" - async', async t => {
 	const nestedFile = path.resolve(t.context.tmp, 'a/b/c/nested.js');
-	makeDir.sync(nestedFile);
+	makeDirectorySync(nestedFile);
 
 	const removeFiles = await deleteAsync([nestedFile], {cwd: t.context.tmp, dryRun: true});
 
@@ -346,7 +346,7 @@ test('windows can pass relative paths with "\\" - async', async t => {
 
 test('windows can pass relative paths with "\\" - sync', t => {
 	const nestedFile = path.resolve(t.context.tmp, 'a/b/c/nested.js');
-	makeDir.sync(nestedFile);
+	makeDirectorySync(nestedFile);
 
 	const removeFiles = deleteSync([nestedFile], {cwd: t.context.tmp, dryRun: true});
 
@@ -356,9 +356,11 @@ test('windows can pass relative paths with "\\" - sync', t => {
 test('onProgress option - progress of non-existent file', async t => {
 	let report;
 
-	await deleteAsync('non-existent-directory', {onProgress(event) {
-		report = event;
-	}});
+	await deleteAsync('non-existent-directory', {
+		onProgress(event) {
+			report = event;
+		},
+	});
 
 	t.deepEqual(report, {
 		totalCount: 0,
@@ -370,9 +372,11 @@ test('onProgress option - progress of non-existent file', async t => {
 test('onProgress option - progress of single file', async t => {
 	let report;
 
-	await deleteAsync(t.context.tmp, {cwd: __dirname, force: true, onProgress(event) {
-		report = event;
-	}});
+	await deleteAsync(t.context.tmp, {
+		cwd: __dirname, force: true, onProgress(event) {
+			report = event;
+		},
+	});
 
 	t.deepEqual(report, {
 		totalCount: 1,


### PR DESCRIPTION
This PR updates all the dependencies consumed by `del` - particularly moving from `rimraf@3` to `rimraf@5` which upgrades to `glob@9` (unused code path).

The main intention is to resolve as much deprecation warnings from `npm` as possible; but I also bumped minimum supported Node.js version to 18 since that's the oldest version in maintenance, since I presume the upgrade of dependencies would at least warrant a minor and might as well bundle "breaking" changes altogether.

Fixes #162